### PR TITLE
set omnios publisher first

### DIFF
--- a/build_zfs_send.sh
+++ b/build_zfs_send.sh
@@ -101,7 +101,7 @@ if [[ -n "$PUBLISHER_OVERRIDE" ]]; then
 fi
 echo "Setting omnios publisher to $OMNIOS_URL"
 pkg -R $MP unset-publisher omnios
-pkg -R $MP set-publisher --no-refresh -g $OMNIOS_URL omnios
+pkg -R $MP set-publisher -P --no-refresh -g $OMNIOS_URL omnios
 
 zfs snapshot $ZROOT/$name@kayak || fail "snap"
 zfs send $ZROOT/$name@kayak | $BZIP2 -9 > $OUT || fail "send/compress"


### PR DESCRIPTION
When using profiles with build_zfs_send -p, the omnios publisher is set as the last in the publisher order. This breaks zone creation:

```
# zoneadm -z foo install
A ZFS file system has been created for this zone.
   Publisher: Using niksula.hut.fi (http://pkg.niksula.hut.fi/ ).
   Publisher: Using omnios (http://pkg.omniti.com/omnios/release/).
       Image: Preparing at /zones/foo/root.
       Cache: Using /var/pkg/publisher.
Sanity Check: Looking for 'entire' incorporation.
ERROR: Unable to locate the incorporation 'entire@11,5.11-0.151006:20131210T224515Z' in the preferred publisher 'niksula.hut.fi'.
Use -P to supply a publisher which contains this package.
```

The fix is trivial, just set the omnios publisher as first in order.
