### PR TITLE
AutoHostname bugfix + enhancement

### DIFF
--- a/install_help.sh
+++ b/install_help.sh
@@ -189,7 +189,8 @@ AutoHostname() {
           /bin/tr '[:upper:]' '[:lower:]' | \
           /bin/sed -e 's/^/ 0/g;s/:/-0/g; s/0\([0-9a-f][0-9a-f]\)/\1/g; s/ //g;'`
   [ -z $suffix ] && suffix=omnios
-  SetHostname $macadr-$suffix
+  [ "$suffix" == "-" ] && suffix= || suffix=-$suffix
+  SetHostname $macadr$suffix
 }
 
 SetTimezone()


### PR DESCRIPTION
Hello All

Here is the bug fix for zero padding of the MACs. (Mentioned in issue #4)
Additionally included is support to prove "-" as parameter to AutoHostname to not include a suffix and just use the MAC as hostname.

Greetings

Hal9k
