### PR TITLE
Vim in miniroot needs libncurses

### DIFF
--- a/data/known_extras
+++ b/data/known_extras
@@ -47,7 +47,12 @@
 0 /usr/bin/ps
 0 /usr/bin/i86/pfiles
 0 /usr/bin/pfiles
+0 /usr/bin/vi
 0 /usr/bin/vim
+0 /usr/lib/libncurses.so.5
+0 /usr/lib/libncurses.so.5.9
+0 /usr/lib/amd64/libncurses.so.5
+0 /usr/lib/amd64/libncurses.so.5.9
 0 /usr/lib/lddstub
 0 /usr/lib/libidn.so.11
 0 /usr/lib/libidn.so.11.6.13


### PR DESCRIPTION
While we're at it, also save the vi->vim symlink.