### PR TITLE
Add nvme to miniroot

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -165,7 +165,7 @@ DRIVERS="driver/audio driver/crypto/dca driver/crypto/tpm driver/firewire
 	driver/storage/sbp2 driver/storage/scsa1394 driver/storage/sdcard
 	driver/storage/ses driver/storage/si3124 driver/storage/smp
 	driver/usb driver/usb/ugen driver/xvm/pv driver/storage/vioblk
-	driver/network/vioif"
+	driver/network/vioif driver/storage/nvme"
 
 PARTS="release/name release/notices service/picl install/beadm SUNWcs SUNWcsd
 	library/libidn shell/pipe-viewer text/less /network/ssh editor/vim

--- a/data/kernel
+++ b/data/kernel
@@ -406,6 +406,7 @@
 0 /kernel/drv/amd64/devinfo
 0 /kernel/drv/amd64/vioblk
 0 /kernel/drv/amd64/vioif
+0 /kernel/drv/amd64/nvme
 0 /kernel/drv/cmdk.conf
 0 /kernel/drv/tavor.conf
 0 /kernel/drv/aggr.conf
@@ -531,6 +532,7 @@
 0 /kernel/drv/bscv.conf
 0 /kernel/drv/sad.conf
 0 /kernel/drv/pppt.conf
+0 /kernel/drv/nvme.conf
 0 /kernel/dtrace/amd64
 0 /kernel/dtrace/amd64/sdt
 0 /kernel/dtrace/amd64/lockstat


### PR DESCRIPTION
Full NVMe install support will require that
pkg:/driver/storage/nvme is part of the default install, which it
currently is not.

Resolves #11 