### PR TITLE
Stop using early-manifest-import directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,20 +98,20 @@ server-dirs:
 	mkdir -p $(DESTDIR)/usr/share/kayak/data
 	mkdir -p $(DESTDIR)/usr/share/kayak/sample
 	mkdir -p $(DESTDIR)/var/kayak/log
-	mkdir -p $(DESTDIR)/lib/svc/manifest/network
-	mkdir -p $(DESTDIR)/lib/svc/method
+	mkdir -p $(DESTDIR)/var/svc/manifest/network
+	mkdir -p $(DESTDIR)/var/svc/method
 
 install-package:	tftp-dirs server-dirs
 	for file in $(INSTALLS) ; do \
 		cp $$file $(DESTDIR)/usr/share/kayak/$$file ; \
 	done
-	cp http/svc-kayak $(DESTDIR)/lib/svc/method/svc-kayak
-	chmod a+x $(DESTDIR)/lib/svc/method/svc-kayak
+	cp http/svc-kayak $(DESTDIR)/var/svc/method/svc-kayak
+	chmod a+x $(DESTDIR)/var/svc/method/svc-kayak
 	cp http/css/land.css $(DESTDIR)/var/kayak/css/land.css
 	for file in $(IMG_FILES) ; do \
 		cp http/img/$$file $(DESTDIR)/var/kayak/img/$$file ; \
 	done
-	cp http/kayak.xml $(DESTDIR)/lib/svc/manifest/network/kayak.xml
+	cp http/kayak.xml $(DESTDIR)/var/svc/manifest/network/kayak.xml
 
 install-tftp:	tftp-dirs $(TFTP_FILES)
 

--- a/http/kayak.xml
+++ b/http/kayak.xml
@@ -58,7 +58,7 @@
 	<exec_method
 		type='method'
 		name='start'
-		exec='/lib/svc/method/svc-kayak -u nobody -g nobody'
+		exec='/var/svc/method/svc-kayak -u nobody -g nobody'
 		timeout_seconds='60'>
 		<method_context>
 			<method_credential user='root' group='root' />

--- a/http/svc-kayak
+++ b/http/svc-kayak
@@ -126,6 +126,7 @@ if __name__ == '__main__':
             '/img': {'tools.staticdir.on': True,
                      'tools.staticdir.dir': os.path.join(options.basedir,'img')},
             '/kayak': {'tools.staticdir.on': True,
+                       'tools.staticdir.content_types': {'': 'text/plain'},
                        'tools.staticdir.dir': os.path.join(options.basedir,'kayak')}}
     root = Root(options)
     root.kayaklog = KayakLog(options)


### PR DESCRIPTION
We've been (ab)using the /lib/svc locations, which are technically
reserved for early-manifest-import (PSARC 2010/013).  Use the more
appropriate /var/svc locations instead.