### PR TITLE
modified rpool-install.sh for tzselect

### DIFF
--- a/data/known_extras
+++ b/data/known_extras
@@ -72,3 +72,8 @@
 0 /usr/bin/md5sum
 0 /usr/gnu/bin/sha1sum
 0 /usr/bin/sha1sum
+0 /usr/bin/gettext
+0 /usr/bin/locale
+0 /usr/bin/printf
+0 /usr/bin/tee
+0 /usr/bin/tzselect

--- a/rpool-install.sh
+++ b/rpool-install.sh
@@ -58,14 +58,9 @@ until [[ $NEWHOST == "" ]]; do
 done
 
 # Select a timezone.
-NEWTZ=$TZ
-until [[ $NEWTZ == "" ]]; do
-    TZ=$NEWTZ
-    echo "Current timezone is [$TZ]:  " `TZ=$TZ date`
-    echo "(NOTE: If time/date above looks wrong, the timezone name doesn't exist.)"
-    echo -n "Enter a new timezone, or just hit RETURN to accept [$TZ]: "
-    read NEWTZ
-done
+tzselect |& tee /tmp/tz.$$
+TZ=$(tail -1 /tmp/tz.$$)
+rm -f /tmp/tz.$$
 
 # Because of kayak's small miniroot, just use C as the language for now.
 LANG=C


### PR DESCRIPTION
use tzselect instead of enter the $TZ manually
-----
0 == done, 1-7 == select-disk 8 == next-page, 9 == clear
\--------------------------------------------------------
\#    TYPE    DISK                    VID      PID              SIZE          RMV SSD

1     SCSI    c3t0d0                  VMware,  VMware Virtual S   30.00 GiB   no  no

Enter a digit or the disk device name ==> 1
root pool disks: [c3t0d0]
0 == done, 1-7 == select-disk 8 == next-page, 9 == clear
\--------------------------------------------------------
\#    TYPE    DISK                    VID      PID              SIZE          RMV SSD

1     SCSI    c3t0d0                  VMware,  VMware Virtual S   30.00 GiB   no  no

Enter a digit or the disk device name ==> 0
Enter the root pool name or press RETURN if you want [rpool]:
[2017/04/20-17:35:44] Disks being used for root pool rpool: c3t0d0
[2017/04/20-17:35:44] zpool destroy rpool (just in case we've been run twice)
[2017/04/20-17:35:44] Creating root pool with: zpool create -f rpool   c3t0d0

Installing from ZFS image /root/*.zfs.bz2
Please enter a hostname or press RETURN if you want [unknown]: Please identify a location so that time zone rules can be set correctly.
Please select a continent or ocean.
 1) Africa
 2) Americas
 3) Antarctica
 4) Arctic Ocean
 5) Asia
 6) Atlantic Ocean
 7) Australia
 8) Europe
 9) Indian Ocean
10) Pacific Ocean
11) none - I want to specify the time zone using the POSIX TZ format.
#? 8
Please select a country or region.
 1) Albania              18) Guernsey             35) Poland
 2) Andorra              19) Hungary              36) Portugal
 3) Austria              20) Ireland              37) Romania
 4) Belarus              21) Isle of Man          38) Russia
 5) Belgium              22) Italy                39) San Marino
 6) Bosnia & Herzegovina 23) Jersey               40) Serbia
 7) Britain (UK)         24) Latvia               41) Slovakia
 8) Bulgaria             25) Liechtenstein        42) Slovenia
 9) Croatia              26) Lithuania            43) Spain
10) Czech Republic       27) Luxembourg           44) Sweden
11) Denmark              28) Macedonia            45) Switzerland
12) Estonia              29) Malta                46) Turkey
13) Finland              30) Moldova              47) Ukraine
14) France               31) Monaco               48) Vatican City
15) Germany              32) Montenegro           49) Cland Islands
16) Gibraltar            33) Netherlands
17) Greece               34) Norway
#? 15
Please select one of the following time zone regions.
1) Germany (most areas)
2) Busingen
#? 1

The following information has been given:

        Germany
        Germany (most areas)

Therefore TZ='Europe/Berlin' will be used.
Local time is now:       Thu Apr 20 19:35:51 CEST 2017
Universal Time is now:   Thu Apr 20 17:35:51 UTC 2017
Is the above information OK?
1) Yes
2) No
#? 1
Here is the TZ value again, this time on standard output:
Europe/Berlin
[2017/04/20-19:36:05] Receiving image: /root/kayak_r151021.zfs.bz2
67.2MiB 0:00:10 [ 6.5MiB/s] [         <=>                                    ]